### PR TITLE
feat: support custom defaults in bookmarks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,8 @@
 #![allow(
     clippy::missing_errors_doc,
     clippy::module_name_repetitions,
-    clippy::option_if_let_else
+    clippy::option_if_let_else,
+    clippy::implicit_hasher
 )]
 
 pub mod cargo;

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,5 +1,5 @@
 pub use self::{
-    global::{load as load_global, Settings as GlobalSettings},
+    global::{load as load_global, DefaultValue, Settings as GlobalSettings},
     repo::{fill_context, load as load_repo, new_context, FileIgnore, RepoSettings},
 };
 

--- a/src/settings/repo/prompts.rs
+++ b/src/settings/repo/prompts.rs
@@ -1,4 +1,6 @@
-use anyhow::Result;
+use std::collections::HashSet;
+
+use anyhow::{anyhow, bail, Result};
 use crossterm::style::Stylize;
 use inquire::{Confirm, CustomType, MultiSelect, Select, Text};
 
@@ -7,7 +9,11 @@ use super::{
     StringValidator,
 };
 
-pub fn prompt_bool(description: &str, setting: &BoolSetting) -> Result<bool> {
+pub fn prompt_bool(
+    description: &str,
+    setting: &BoolSetting,
+    default: Option<bool>,
+) -> Result<bool> {
     fn default_value_formatter(value: bool) -> String {
         if value {
             format!("{}/n", "Y".green())
@@ -18,12 +24,16 @@ pub fn prompt_bool(description: &str, setting: &BoolSetting) -> Result<bool> {
 
     let mut prompt =
         Confirm::new(description).with_default_value_formatter(&default_value_formatter);
-    prompt.default = setting.default;
+    prompt.default = default.or(setting.default);
 
     prompt.prompt().map_err(Into::into)
 }
 
-pub fn prompt_string(description: &str, setting: StringSetting) -> Result<String> {
+pub fn prompt_string(
+    description: &str,
+    setting: StringSetting,
+    default: Option<&str>,
+) -> Result<String> {
     let validator: Box<dyn Fn(&str) -> Result<(), String>> = match setting.validator {
         None => Box::new(validators::required),
         Some(StringValidator::Crate) => Box::new(validators::krate),
@@ -33,13 +43,21 @@ pub fn prompt_string(description: &str, setting: StringSetting) -> Result<String
         Some(StringValidator::Regex(re)) => Box::new(validators::regex(re)),
     };
 
+    if let Some(default) = default {
+        validator(default).map_err(|err| anyhow!("Invalid default `{default}` {err}"))?;
+    }
+
     let mut prompt = Text::new(description).with_validator(&*validator);
-    prompt.default = setting.default.as_deref();
+    prompt.default = default.or(setting.default.as_deref());
 
     prompt.prompt().map_err(Into::into)
 }
 
-pub fn prompt_number<T: Number>(description: &str, setting: &NumberSetting<T>) -> Result<T> {
+pub fn prompt_number<T: Number>(
+    description: &str,
+    setting: &NumberSetting<T>,
+    default: Option<T>,
+) -> Result<T> {
     fn parser<T: Number>(value: &str, min: T, max: T) -> Result<T, ()> {
         match value.parse() {
             Ok(v) if (min..=max).contains(&v) => Ok(v),
@@ -49,6 +67,16 @@ pub fn prompt_number<T: Number>(description: &str, setting: &NumberSetting<T>) -
 
     fn formatter<T: Number>(value: T) -> String {
         value.to_string()
+    }
+
+    if let Some(default) = default {
+        if !(setting.min..=setting.max).contains(&default) {
+            bail!(
+                "Invalid default `{default}` value is not in range {} to {}",
+                setting.min,
+                setting.max
+            );
+        }
     }
 
     let parser = |value: &str| parser(value, setting.min, setting.max);
@@ -61,18 +89,23 @@ pub fn prompt_number<T: Number>(description: &str, setting: &NumberSetting<T>) -
         .with_help_message(&help_message)
         .with_error_message("Please type a valid number within range.");
 
-    if let Some(default) = setting.default {
+    if let Some(default) = default.or(setting.default) {
         prompt.default = Some((default, &formatter));
     }
 
     prompt.prompt().map_err(Into::into)
 }
 
-pub fn prompt_list(description: &str, setting: ListSetting) -> Result<String> {
+pub fn prompt_list(
+    description: &str,
+    setting: ListSetting,
+    default: Option<&str>,
+) -> Result<String> {
     let default = setting
         .values
         .iter()
-        .position(|v| Some(v) == setting.default.as_ref())
+        // Maybe use `and_then?`
+        .position(|v| Some(v.as_str()) == default.or(setting.default.as_deref()))
         .unwrap_or_default();
 
     let prompt = Select::new(description, setting.values.into_iter().collect())
@@ -81,8 +114,12 @@ pub fn prompt_list(description: &str, setting: ListSetting) -> Result<String> {
     prompt.prompt().map_err(Into::into)
 }
 
-pub fn prompt_multi_list(description: &str, setting: MultiListSetting) -> Result<Vec<String>> {
-    let (index, selection) = if let Some(default) = setting.default.as_ref() {
+pub fn prompt_multi_list(
+    description: &str,
+    setting: MultiListSetting,
+    default: Option<&HashSet<String>>,
+) -> Result<Vec<String>> {
+    let (index, selection) = if let Some(default) = default.or(setting.default.as_ref()) {
         let index = setting
             .values
             .iter()


### PR DESCRIPTION

By far not the cleanest implementation, if you think this or someone like this makes sense, this would probably need to be partly refactored.

This is more of a quickly thrown together aproach to having some form of global values.


I first thought of global values set for all templates, but that would easily clash because multiple templates could use the same key for different use cases.


(My usecase is e.g. the GitHub account/org).
